### PR TITLE
compress data

### DIFF
--- a/inst/scripts/compress_data.R
+++ b/inst/scripts/compress_data.R
@@ -1,0 +1,7 @@
+# ---- resave the .rds files in data/ with compressed format ----
+#
+# details:
+#   The type of compression is chosen automatically by tools
+#   This command need only be run once and may take several minutes.
+
+tools::resaveRdaFiles(paths = 'data')


### PR DESCRIPTION
`inst/scripts/compress_data.R` contains a command to compress the files in `data/` that should speed up the installation of the package, as discussed in issue #5. The command (`tools::resaveRdaFiles`) uses its own heuristics to select a compression method based on the size of the file, which seems to diverge slightly from the `usethis::use_data` defaults.